### PR TITLE
fixed white space invalid free

### DIFF
--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -22,20 +22,20 @@ ParsedCommand *parse_command(char *input) {
     char *input_copy = strdup(input);
     if (!input_copy) return NULL;
     
-    char *first_addres_of_input_copy = input_copy;
+    char *original_input_copy = input_copy;
     input_copy = trim_whitespace(input_copy);
     if (strlen(input_copy) == 0) {
         PARSER_DEBUG("Empty command after trimming");
-        free(first_addres_of_input_copy);
-        first_addres_of_input_copy =NULL;
+        free(original_input_copy);
+        original_input_copy = NULL;
         return NULL;
     }
     
     ParsedCommand *cmd = calloc(1, sizeof(ParsedCommand));
     if (!cmd) {
         PARSER_DEBUG("Failed to allocate ParsedCommand");
-        free(first_addres_of_input_copy);
-        first_addres_of_input_copy =NULL;
+        free(original_input_copy);
+        original_input_copy = NULL;
         return NULL;
     }
     
@@ -43,8 +43,8 @@ ParsedCommand *parse_command(char *input) {
     cmd->args = calloc(MAX_ARGS, sizeof(char *));
     if (!cmd->args) {
         PARSER_DEBUG("Failed to allocate args array");
-        free(first_addres_of_input_copy);
-        first_addres_of_input_copy = NULL;
+        free(original_input_copy);
+        original_input_copy = NULL;
         free(cmd);
         return NULL;
     }
@@ -88,9 +88,9 @@ ParsedCommand *parse_command(char *input) {
     
     PARSER_DEBUG("Command parsed with %d arguments", arg_count);
 
-    if(first_addres_of_input_copy){
-        free(first_addres_of_input_copy);
-        first_addres_of_input_copy = NULL;
+    if(original_input_copy){
+        free(original_input_copy);
+        original_input_copy = NULL;
     }
 
 

--- a/src/core/parser.c
+++ b/src/core/parser.c
@@ -22,17 +22,20 @@ ParsedCommand *parse_command(char *input) {
     char *input_copy = strdup(input);
     if (!input_copy) return NULL;
     
+    char *first_addres_of_input_copy = input_copy;
     input_copy = trim_whitespace(input_copy);
     if (strlen(input_copy) == 0) {
         PARSER_DEBUG("Empty command after trimming");
-        free(input_copy);
+        free(first_addres_of_input_copy);
+        first_addres_of_input_copy =NULL;
         return NULL;
     }
     
     ParsedCommand *cmd = calloc(1, sizeof(ParsedCommand));
     if (!cmd) {
         PARSER_DEBUG("Failed to allocate ParsedCommand");
-        free(input_copy);
+        free(first_addres_of_input_copy);
+        first_addres_of_input_copy =NULL;
         return NULL;
     }
     
@@ -40,14 +43,13 @@ ParsedCommand *parse_command(char *input) {
     cmd->args = calloc(MAX_ARGS, sizeof(char *));
     if (!cmd->args) {
         PARSER_DEBUG("Failed to allocate args array");
-        free(input_copy);
+        free(first_addres_of_input_copy);
+        first_addres_of_input_copy = NULL;
         free(cmd);
         return NULL;
     }
-    
     int arg_count = 0;
     char *token, *saveptr = NULL;
-    
     // Tokenize and process input
     token = strtok_r(input_copy, " \t", &saveptr);
     while (token != NULL && arg_count < MAX_ARGS - 1) {
@@ -81,13 +83,17 @@ ParsedCommand *parse_command(char *input) {
         // Get next token
         token = strtok_r(NULL, " \t", &saveptr);
     }
-    
     // Ensure NULL termination
     cmd->args[arg_count] = NULL;
     
     PARSER_DEBUG("Command parsed with %d arguments", arg_count);
-    
-    free(input_copy);
+
+    if(first_addres_of_input_copy){
+        free(first_addres_of_input_copy);
+        first_addres_of_input_copy = NULL;
+    }
+
+
     return cmd;
 }
 


### PR DESCRIPTION

if I executed the app and pass ** ( ccomand) **, it generates a free invalid pointer
yes , you must pass [SPACE,comand]
example:
```bash
./nutshell 
--->   ls 
```
### Explanation:
on the file: **src/core/parser.c**
on the function: **ParsedCommand *parse_command(char *input){ (line 16)**

in part  :  ** input_copy = trim_whitespace(input_copy);** (line 26), you were remove a + size of the string
making the oriignal pointer, became some bytes higher than the original size
causing invalid pointer on free
### Solution
create a copy of the original pointer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management and error handling to enhance system stability and prevent potential memory leaks without altering public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->